### PR TITLE
Fix: 수업대상 미  선택시에도  svg 아이콘 등장

### DIFF
--- a/src/views/pages/studentManage/AddNewClassPage.vue
+++ b/src/views/pages/studentManage/AddNewClassPage.vue
@@ -36,7 +36,10 @@
                     :text="option.text"
                     @click="() => selectSchoolType(option)"
                   />
-                  <span class="rightTriangle">
+                  <span
+                    v-if="newClassInfo.schoolType.includes(option.text)"
+                    class="rightTriangle"
+                  >
                     <svg-icon name="rightTriangle" />
                   </span>
                 </li>
@@ -150,7 +153,6 @@
               v-model:value="newClassInfo.tuition"
               type="text"
               inputmode="text"
-              pattern="^\d*$"
               :maxlength="11"
               :placeholder="'000,000'"
               @keyup="e => onChangePriceFormat(e)"


### PR DESCRIPTION
## Summary (작업사항)

## 변경사유

## Reference (Wiki)

## 체크리스트

## 기타

-수업대상 선택 안되면 svg아이콘 표시 안되게 